### PR TITLE
chore(renovate): ignore io-ts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
       "automerge": true
     }
   ],
+  "ignoreDeps": ["io-ts"],
   "timezone": "America/Chicago",
   "schedule": ["after 10pm every weekday", "before 5am every weekday", "every weekend"]
 }


### PR DESCRIPTION
We want to keeep pinned to the stable version 2.1.3, and io-ts
has not kept to semver for experimental/breaking changes.

Until io-ts 3 lands and we want to adopt, let's disable automatic
dependency upgrades.